### PR TITLE
Added ignore_members variable and use it in opsgenie_team resource

### DIFF
--- a/examples/complete/team.tf
+++ b/examples/complete/team.tf
@@ -4,8 +4,9 @@ module "team" {
   opsgenie_provider_api_key = var.opsgenie_provider_api_key
 
   team = {
-    name        = module.label.id
-    description = "team-description"
+    name           = module.label.id
+    description    = "team-description"
+    ignore_members = var.ignore_members
   }
 }
 

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -48,3 +48,9 @@ variable "opsgenie_team" {
   description = "This variable is used to configure opsgenie team."
   default     = {}
 }
+
+variable "ignore_members" {
+  type        = bool
+  description = "Set to true to ignore any configured member blocks and any team member added/updated/removed via OpsGenie web UI"
+  default     = false
+}

--- a/modules/team/main.tf
+++ b/modules/team/main.tf
@@ -4,6 +4,7 @@ provider "opsgenie" {
 }
 
 resource "opsgenie_team" "this" {
-  name        = var.team.name
-  description = try(var.team.description, var.team.name)
+  name           = var.team.name
+  description    = try(var.team.description, var.team.name)
+  ignore_members = var.ignore_members
 }

--- a/modules/team/main.tf
+++ b/modules/team/main.tf
@@ -6,5 +6,5 @@ provider "opsgenie" {
 resource "opsgenie_team" "this" {
   name           = var.team.name
   description    = try(var.team.description, var.team.name)
-  ignore_members = var.ignore_members
+  ignore_members = try(var.team.ignore_members, false)
 }

--- a/modules/team/variables.tf
+++ b/modules/team/variables.tf
@@ -1,9 +1,3 @@
-variable "ignore_members" {
-  type        = bool
-  description = "Set to true to ignore any configured member blocks and any team member added/updated/removed via OpsGenie web UI"
-  default     = false
-}
-
 variable "opsgenie_provider_api_key" {
   type        = string
   description = "The API Key for the Opsgenie Integration. If omitted, the OPSGENIE_API_KEY environment variable is used."

--- a/modules/team/variables.tf
+++ b/modules/team/variables.tf
@@ -1,3 +1,9 @@
+variable "ignore_members" {
+  type        = bool
+  description = "Set to true to ignore any configured member blocks and any team member added/updated/removed via OpsGenie web UI"
+  default     = false
+}
+
 variable "opsgenie_provider_api_key" {
   type        = string
   description = "The API Key for the Opsgenie Integration. If omitted, the OPSGENIE_API_KEY environment variable is used."


### PR DESCRIPTION
## what
* adds a variable `ignore_members` to the team module that is passed to the `opsgenie_team` resource.  Defaults to false.

## why
* Ignoring changes to team membership, allows you to manage that in the Opsgenie UI.  This is particularly useful for delegating team membership to team leads, for example.

## references
[* Opsgenie team resource docs](https://registry.terraform.io/providers/opsgenie/opsgenie/latest/docs/resources/team)


## implementation note
I tried both, setting `ignore_members` as a variable (first commit) and putting it into the `team` map (second commit).   Not sure how you guys like it.