### PR TITLE
Config module can be used with single type resource

### DIFF
--- a/modules/config/alert_policies.tf
+++ b/modules/config/alert_policies.tf
@@ -1,6 +1,6 @@
 resource "opsgenie_alert_policy" "this" {
   for_each = {
-    for policy in var.opsgenie_resources.alert_policies : policy.name => policy
+    for policy in local.alert_policies : policy.name => policy
   }
 
   name               = each.value.name

--- a/modules/config/api_integrations.tf
+++ b/modules/config/api_integrations.tf
@@ -1,6 +1,6 @@
 resource "opsgenie_api_integration" "this" {
   for_each = {
-    for integration in var.opsgenie_resources.api_integrations : integration.name => integration
+    for integration in local.api_integrations : integration.name => integration
   }
 
   name = each.value.name

--- a/modules/config/escalations.tf
+++ b/modules/config/escalations.tf
@@ -1,6 +1,6 @@
 resource "opsgenie_escalation" "this" {
   for_each = {
-    for escalation in var.opsgenie_resources.escalations : escalation.name => escalation
+    for escalation in local.escalations : escalation.name => escalation
   }
 
   name        = each.value.name

--- a/modules/config/main.tf
+++ b/modules/config/main.tf
@@ -1,0 +1,8 @@
+locals {
+  alert_policies        = try(var.opsgenie_resources.alert_policies, [])
+  api_integrations      = try(var.opsgenie_resources.api_integrations, [])
+  escalations           = try(var.opsgenie_resources.escalations, [])
+  notification_policies = try(var.opsgenie_resources.notification_policies, [])
+  team_routing_rules    = try(var.opsgenie_resources.team_routing_rules, [])
+  teams                 = try(var.opsgenie_resources.teams, [])
+}

--- a/modules/config/notification_policies.tf
+++ b/modules/config/notification_policies.tf
@@ -1,6 +1,6 @@
 resource "opsgenie_notification_policy" "this" {
   for_each = {
-    for policy in var.opsgenie_resources.notification_policies : policy.name => policy
+    for policy in local.notification_policies : policy.name => policy
   }
 
   enabled = try(each.value.enabled, true)

--- a/modules/config/team_routing_rules.tf
+++ b/modules/config/team_routing_rules.tf
@@ -1,6 +1,6 @@
 resource "opsgenie_team_routing_rule" "this" {
   for_each = {
-    for rule in var.opsgenie_resources.team_routing_rules : rule.name => rule
+    for rule in local.team_routing_rules : rule.name => rule
   }
 
   name = each.value.name

--- a/modules/config/teams.tf
+++ b/modules/config/teams.tf
@@ -1,6 +1,6 @@
 resource "opsgenie_team" "this" {
   for_each = {
-    for team in var.opsgenie_resources.teams : team.name => team
+    for team in local.teams : team.name => team
   }
 
   name        = each.value.name


### PR DESCRIPTION
## what
* Config module can be used with single type resource - for example just `team` or `alert_policy`

## why
* Defining all modules is not always possible/convenient
