### PR TITLE
Added ignore_members and delete_default_resource attributes to teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -162,6 +163,7 @@ No provider.
 
 No output.
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,9 +1,10 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.26 |
-| opsgenie/opsgenie | ~> 0.4 |
+| opsgenie | ~> 0.4 |
 
 ## Providers
 
@@ -32,3 +33,4 @@ No provider.
 
 No output.
 
+<!-- markdownlint-restore -->

--- a/examples/config/resources/teams.yaml
+++ b/examples/config/resources/teams.yaml
@@ -3,5 +3,9 @@ teams:
   description: Global Team for Acme Co.
 - name: acme.dev
   description: Acme Dev Team
+  delete_default_resources: true
 - name: acme.dev.some-service
   description: "repo: https://github.com/acme/some-service;owner:David Lightman @David Lightman"
+  ignore_members: true
+  delete_default_resources: true
+

--- a/modules/config/teams.tf
+++ b/modules/config/teams.tf
@@ -3,6 +3,8 @@ resource "opsgenie_team" "this" {
     for team in local.teams : team.name => team
   }
 
-  name        = each.value.name
-  description = each.value.description
+  name                     = each.value.name
+  description              = each.value.description
+  ignore_members           = try(each.value.ignore_members, false)
+  delete_default_resources = try(each.value.delete_default_resources, false)
 }

--- a/modules/config/teams.tf
+++ b/modules/config/teams.tf
@@ -4,7 +4,7 @@ resource "opsgenie_team" "this" {
   }
 
   name                     = each.value.name
-  description              = try(each.value.description, var.team.name)
+  description              = try(each.value.description, each.value.name)
   ignore_members           = try(each.value.ignore_members, false)
   delete_default_resources = try(each.value.delete_default_resources, false)
 }

--- a/modules/config/teams.tf
+++ b/modules/config/teams.tf
@@ -4,7 +4,7 @@ resource "opsgenie_team" "this" {
   }
 
   name                     = each.value.name
-  description              = each.value.description
+  description              = try(each.value.description, var.team.name)
   ignore_members           = try(each.value.ignore_members, false)
   delete_default_resources = try(each.value.delete_default_resources, false)
 }

--- a/modules/team/README.md
+++ b/modules/team/README.md
@@ -18,6 +18,18 @@ module "team" {
 
 }
 
+module "ui_managed_team" {
+  source = "git::https://github.com/cloudposse/terraform-opsgenie-incident-management.git//modules/team?ref=master"
+
+  team = {
+    name                     = module.label.id
+    description              = "team-description"
+    delete_default_resources = true
+    ignore_members           = true
+  }
+
+}
+
 ```
 
 ## Inputs

--- a/modules/team/main.tf
+++ b/modules/team/main.tf
@@ -1,5 +1,6 @@
 resource "opsgenie_team" "this" {
-  name           = var.team.name
-  description    = try(var.team.description, var.team.name)
-  ignore_members = try(var.team.ignore_members, false)
+  name                     = var.team.name
+  description              = try(var.team.description, var.team.name)
+  ignore_members           = try(var.team.ignore_members, false)
+  delete_default_resources = try(var.team.delete_default_resources, false)
 }


### PR DESCRIPTION
## what
This PR adds the following arguments to the `config` module's team functionality:
* delete_default_resources: true
* ignore_members

## why
*   `delete_default_resources` provides for wanting to suppress default object creation for teams
* `ignore_members` allows teams' memberships to be managed in the UI, without impacting TF



