### PR TITLE
Change for_each to avoid nested maps typing_error

### DIFF
--- a/modules/config/integration_actions.tf
+++ b/modules/config/integration_actions.tf
@@ -1,5 +1,5 @@
 resource "opsgenie_integration_action" "this" {
-  for_each = module.this.enabled ? { for integration_action in local.integration_actions : integration_action.name => integration_action } : {}
+  for_each = { for integration_action in local.integration_actions : integration_action.name => integration_action if module.this.enabled }
 
   # Look up our integration id by name
   integration_id = try(opsgenie_api_integration.this[each.value.integration_name].id, null)


### PR DESCRIPTION
## what
* Fix conditional operator

## why
* Prevent terraform errors like

```
Error: Inconsistent conditional result types

  on .terraform/modules/opsgenie_config/modules/config/integration_actions.tf line 2, in resource "opsgenie_integration_action" "this":
   2:   for_each = module.this.enabled ? { for integration_action in local.integration_actions : integration_action.name => integration_action } : {}
    |----------------
    | local.integration_actions is tuple with 14 elements
    | module.this.enabled is true

The true and false result expressions must have consistent types. The given
expressions are object and object, respectively.
```


## references
* https://stackoverflow.com/questions/66970542/inconsistent-conditional-result-types-with-locals-templatization

