### PR TITLE
Module `schedule`

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2021-2021 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2021-2022 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/examples/schedule/context.tf
+++ b/examples/schedule/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/examples/schedule/fixtures.tfvars
+++ b/examples/schedule/fixtures.tfvars
@@ -1,0 +1,4 @@
+enabled   = true
+namespace = "eg"
+name      = "schedule"
+stage     = "test"

--- a/examples/schedule/main.tf
+++ b/examples/schedule/main.tf
@@ -1,0 +1,29 @@
+provider "opsgenie" {
+  api_key = var.opsgenie_provider_api_key
+}
+module "owner_team" {
+  source = "../../modules/team"
+
+  team = {
+    name        = "owner-team"
+    description = "owner-team-description"
+  }
+}
+
+module "team_schedule" {
+  source = "../../modules/schedule"
+  schedule = {
+    enabled       = module.this.enabled
+    name          = module.this.id
+    description   = "schedule-description"
+    owner_team_id = try(module.owner_team.team_id, null)
+  }
+}
+module "schedule" {
+  source = "../../modules/schedule"
+  schedule = {
+    enabled       = module.this.enabled
+    name          = module.this.id
+    description   = "schedule-description"
+  }
+}

--- a/examples/schedule/main.tf
+++ b/examples/schedule/main.tf
@@ -17,7 +17,7 @@ module "team_schedule" {
   schedule = {
     enabled       = module.this.enabled
     name          = module.this.id
-    description   = "schedule-description"
+    description   = "team-schedule-description"
     owner_team_id = module.owner_team.team_id
   }
 }

--- a/examples/schedule/main.tf
+++ b/examples/schedule/main.tf
@@ -1,6 +1,7 @@
 provider "opsgenie" {
   api_key = var.opsgenie_provider_api_key
 }
+
 module "owner_team" {
   source = "../../modules/team"
 
@@ -12,15 +13,18 @@ module "owner_team" {
 
 module "team_schedule" {
   source = "../../modules/schedule"
+
   schedule = {
     enabled       = module.this.enabled
     name          = module.this.id
     description   = "schedule-description"
-    owner_team_id = try(module.owner_team.team_id, null)
+    owner_team_id = module.owner_team.team_id
   }
 }
+
 module "schedule" {
   source = "../../modules/schedule"
+
   schedule = {
     enabled     = module.this.enabled
     name        = module.this.id

--- a/examples/schedule/main.tf
+++ b/examples/schedule/main.tf
@@ -22,8 +22,8 @@ module "team_schedule" {
 module "schedule" {
   source = "../../modules/schedule"
   schedule = {
-    enabled       = module.this.enabled
-    name          = module.this.id
-    description   = "schedule-description"
+    enabled     = module.this.enabled
+    name        = module.this.id
+    description = "schedule-description"
   }
 }

--- a/examples/schedule/outputs.tf
+++ b/examples/schedule/outputs.tf
@@ -1,0 +1,14 @@
+output "team" {
+  description = "Opsgenie Team"
+  value       = module.team
+}
+
+output "team_id" {
+  description = "The ID of the Opsgenie Team"
+  value       = module.team.team_id
+}
+
+output "team_name" {
+  description = "The name of the Opsgenie Team"
+  value       = module.team.team_name
+}

--- a/examples/schedule/variables.tf
+++ b/examples/schedule/variables.tf
@@ -1,0 +1,5 @@
+variable "opsgenie_provider_api_key" {
+  type        = string
+  description = "The API Key for the Opsgenie Integration. If omitted, the OPSGENIE_API_KEY environment variable is used"
+  default     = null
+}

--- a/examples/schedule/versions.tf
+++ b/examples/schedule/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     opsgenie = {
       source  = "opsgenie/opsgenie"
-      version = ">= 0.4"
+      version = ">= 0.6.7"
     }
   }
 }

--- a/examples/schedule/versions.tf
+++ b/examples/schedule/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13.0"
+
+  required_providers {
+    opsgenie = {
+      source  = "opsgenie/opsgenie"
+      version = ">= 0.4"
+    }
+  }
+}

--- a/modules/schedule/README.md
+++ b/modules/schedule/README.md
@@ -31,7 +31,7 @@ module "team_schedule" {
 
   schedule = {
     name                     = module.label.id
-    description              = "schedule-description"
+    description              = "team-schedule-description"
     owner_team_id            = data.opsgenie_team.the_team.id
   }
 }

--- a/modules/schedule/README.md
+++ b/modules/schedule/README.md
@@ -22,6 +22,7 @@ module "schedule" {
 data "opsgenie_team" "the_team" {
   name  = var.team_name
 }
+
 module "team_schedule" {
   source  = "cloudposse/incident-management/opsgenie//modules/schedule"
   # Cloud Posse recommends pinning every module to a specific version
@@ -33,7 +34,6 @@ module "team_schedule" {
     owner_team_id            = data.opsgenie_team.the_team.id
   }
 }
-
 ```
 
 ## Inputs

--- a/modules/schedule/README.md
+++ b/modules/schedule/README.md
@@ -1,0 +1,55 @@
+## schedule
+
+Terraform module to configure [Opsgenie Schedule](https://registry.terraform.io/providers/opsgenie/opsgenie/latest/docs/resources/schedule)
+
+
+## Usage
+
+[Create Opsgenie Schedule example](../../examples/schedule)
+
+```hcl
+module "schedule" {
+  source  = "cloudposse/incident-management/opsgenie//modules/schedule"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version     = "x.x.x"
+
+  schedule = {
+    name        = module.label.id
+    description = "schedule-description"
+  }
+}
+
+data "opsgenie_team" "the_team" {
+  name  = var.team_name
+}
+module "team_schedule" {
+  source  = "cloudposse/incident-management/opsgenie//modules/schedule"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version     = "x.x.x"
+
+  schedule = {
+    name                     = module.label.id
+    description              = "schedule-description"
+    owner_team_id            = data.opsgenie_team.the_team.id
+  }
+}
+
+```
+
+## Inputs
+
+**Note:** `schedule` is a map for two reasons: 
+- to be able to put whole configuration in yaml file
+- variables defined with type set are not robust enough (can't set default values)
+
+|  Name                          |  Default                          |  Description                                                                                                                    | Required |
+|:-------------------------------|:---------------------------------:|:--------------------------------------------------------------------------------------------------------------------------------|:--------:|
+| `schedule`                         | `{}`                              | This variable is used to configure Opsgenie schedule.                                                                               | Yes      |
+
+
+## Outputs
+
+| Name                        | Description                              |
+|:----------------------------|:-----------------------------------------|
+| `schedule_name`                 | The name of the Opsgenie schedule.           |
+| `schedule_id`                   | The ID of the Opsgenie schedule.             |

--- a/modules/schedule/README.md
+++ b/modules/schedule/README.md
@@ -5,7 +5,7 @@ Terraform module to configure [Opsgenie Schedule](https://registry.terraform.io/
 
 ## Usage
 
-[Create Opsgenie Schedule example](../../examples/schedule)
+[Opsgenie Schedule example](../../examples/schedule)
 
 ```hcl
 module "schedule" {
@@ -24,6 +24,7 @@ data "opsgenie_team" "the_team" {
 }
 
 module "team_schedule" {
+
   source  = "cloudposse/incident-management/opsgenie//modules/schedule"
   # Cloud Posse recommends pinning every module to a specific version
   # version     = "x.x.x"

--- a/modules/schedule/context.tf
+++ b/modules/schedule/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/modules/schedule/main.tf
+++ b/modules/schedule/main.tf
@@ -1,0 +1,10 @@
+resource "opsgenie_schedule" "default" {
+  count = module.this.enabled ? 1 : 0
+
+  name          = var.schedule.name
+  description   = try(var.schedule.description, var.schedule.name)
+  owner_team_id = try(var.schedule.owner_team_id, null)
+
+  enabled  = try(var.schedule.enabled, true)
+  timezone = try(var.schedule.timezone, null)
+}

--- a/modules/schedule/main.tf
+++ b/modules/schedule/main.tf
@@ -2,9 +2,9 @@ resource "opsgenie_schedule" "default" {
   count = module.this.enabled ? 1 : 0
 
   name          = var.schedule.name
-  description   = try(var.schedule.description, var.schedule.name)
+  description   = try(var.schedule.description, null)
   owner_team_id = try(var.schedule.owner_team_id, null)
 
-  enabled  = try(var.schedule.enabled, true)
+  enabled  = try(var.schedule.enabled, null) # this is the state of the schedule, NOT module.this.enabled
   timezone = try(var.schedule.timezone, null)
 }

--- a/modules/schedule/outputs.tf
+++ b/modules/schedule/outputs.tf
@@ -1,0 +1,4 @@
+output "schedule_id" {
+  description = "The ID of the Opsgenie Schedule"
+  value       = try(opsgenie_schedule.default[*].id, null)
+}

--- a/modules/schedule/outputs.tf
+++ b/modules/schedule/outputs.tf
@@ -1,4 +1,4 @@
 output "schedule_id" {
   description = "The ID of the Opsgenie Schedule"
-  value       = try(opsgenie_schedule.default[*].id, null)
+  value       = try(opsgenie_schedule.default[0].id, null)
 }

--- a/modules/schedule/variables.tf
+++ b/modules/schedule/variables.tf
@@ -1,4 +1,5 @@
 variable "schedule" {
+  type        = map(any)
   default     = {}
   description = "Opsgenie Schedule configuration"
 }

--- a/modules/schedule/variables.tf
+++ b/modules/schedule/variables.tf
@@ -1,0 +1,4 @@
+variable "schedule" {
+  default     = {}
+  description = "Opsgenie Schedule configuration"
+}

--- a/modules/schedule/versions.tf
+++ b/modules/schedule/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     opsgenie = {
       source  = "opsgenie/opsgenie"
-      version = ">= 0.4"
+      version = ">= 0.6.7"
     }
   }
 }

--- a/modules/schedule/versions.tf
+++ b/modules/schedule/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13.0"
+
+  required_providers {
+    opsgenie = {
+      source  = "opsgenie/opsgenie"
+      version = ">= 0.4"
+    }
+  }
+}


### PR DESCRIPTION
## what
* Add a TF `schedule` module

## why
* The terraform schedule module will be used to create and manage on-call schedules

## references
* https://support.atlassian.com/opsgenie/docs/manage-on-call-schedules-and-rotations/
* https://www.atlassian.com/software/opsgenie/on-call-management-and-escalations
* https://support.atlassian.com/opsgenie/docs/build-an-on-call-schedule/
