### PR TITLE
feat(alert_policy): add support for time_restrictions attribute

### DIFF
--- a/modules/alert_policy/main.tf
+++ b/modules/alert_policy/main.tf
@@ -46,4 +46,38 @@ resource "opsgenie_alert_policy" "this" {
       }
     }
   }
+
+  dynamic time_restriction {
+    for_each = try(var.alert_policy.time_restrictions, [])
+
+    content {
+      type = time_restriction.value.type
+      
+      dynamic "restrictions" {
+        for_each = [for s in time_restriction.value.restrictions : s if time_restriction.value.type == "weekday-and-time-of-day"]
+
+        content {
+          end_day    = try(restrictions.value.end_day, null)
+          end_hour   = try(restrictions.value.end_hour, null)
+          end_min    = try(restrictions.value.end_min, null)
+          start_day  = try(restrictions.value.start_day, null)
+          start_hour = try(restrictions.value.start_hour, null)
+          start_min  = try(restrictions.value.start_min, null)
+        }
+      }
+
+      dynamic "restriction" {
+        for_each = [for s in time_restriction.value.restrictions : s if time_restriction.value.type == "time-of-day"]
+
+        content {
+          end_hour   = try(restriction.value.end_hour, null)
+          end_min    = try(restriction.value.end_min, null)
+          start_hour = try(restriction.value.start_hour, null)
+          start_min  = try(restriction.value.start_min, null)
+        }
+      }
+    }
+
+  }
+
 }

--- a/modules/alert_policy/outputs.tf
+++ b/modules/alert_policy/outputs.tf
@@ -27,3 +27,8 @@ output "alert_policy_responders" {
   description = "Responders of the Opsgenie Alert Policy"
   value       = try(opsgenie_alert_policy.this[0].responders, null)
 }
+
+output "alert_policy_time_restrictions" {
+  description = "Time restrictions of the Opsgenie Alert Policy"
+  value       = try(opsgenie_alert_policy.this[0].time_restriction, null)
+}


### PR DESCRIPTION
## what
* Add support for `time_restriction` block in `opsgenie_alert_policy`

## why
* Missing functionality

## references
* [Provider docs](https://registry.terraform.io/providers/opsgenie/opsgenie/latest/docs/resources/alert_policy#argument-reference)

