### PR TITLE
Add config deprecation docs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,9 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
+  "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
     "ignorePaths": ["**/context.tf", "examples/**"]
   }
 }
-

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The table below correctly indicates which inputs are required.
 Here's how to invoke `team` module in your projects
 
 ```hcl
-module "team-name" {
+module "team_name" {
   source  = "cloudposse/incident-management/opsgenie//modules/team"
   # Cloud Posse recommends pinning every module to a specific version
   # version     = "x.x.x"
@@ -422,8 +422,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Marcin Brański][3h4x_avatar]][3h4x_homepage]<br/>[Marcin Brański][3h4x_homepage] | [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Yonatan Koren][korenyoni_avatar]][korenyoni_homepage]<br/>[Yonatan Koren][korenyoni_homepage] | [![Benjamin Smith][benbentwo_avatar]][benbentwo_homepage]<br/>[Benjamin Smith][benbentwo_homepage] |
-|---|---|---|---|---|---|
+|  [![Marcin Brański][3h4x_avatar]][3h4x_homepage]<br/>[Marcin Brański][3h4x_homepage] | [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Igor Rodionov][goruha_avatar]][goruha_homepage]<br/>[Igor Rodionov][goruha_homepage] | [![Yonatan Koren][korenyoni_avatar]][korenyoni_homepage]<br/>[Yonatan Koren][korenyoni_homepage] | [![Benjamin Smith][benbentwo_avatar]][benbentwo_homepage]<br/>[Benjamin Smith][benbentwo_homepage] | [![RB][nitrocode_avatar]][nitrocode_homepage]<br/>[RB][nitrocode_homepage] |
+|---|---|---|---|---|---|---|
 <!-- markdownlint-restore -->
 
   [3h4x_homepage]: https://github.com/3h4x
@@ -438,6 +438,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [korenyoni_avatar]: https://img.cloudposse.com/150x150/https://github.com/korenyoni.png
   [benbentwo_homepage]: https://github.com/benbentwo
   [benbentwo_avatar]: https://img.cloudposse.com/150x150/https://github.com/benbentwo.png
+  [nitrocode_homepage]: https://github.com/nitrocode
+  [nitrocode_avatar]: https://img.cloudposse.com/150x150/https://github.com/nitrocode.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.yaml
+++ b/README.yaml
@@ -80,7 +80,7 @@ usage: |-
   Here's how to invoke `team` module in your projects
 
   ```hcl
-  module "team-name" {
+  module "team_name" {
     source  = "cloudposse/incident-management/opsgenie//modules/team"
     # Cloud Posse recommends pinning every module to a specific version
     # version     = "x.x.x"
@@ -137,3 +137,5 @@ contributors:
     github: "korenyoni"
   - name: "Benjamin Smith"
     github: "benbentwo"
+  - name: "RB"
+    github: "nitrocode"

--- a/examples/config/main.tf
+++ b/examples/config/main.tf
@@ -11,6 +11,8 @@ locals {
   ]...)
 }
 
+# NOTE: Usage of the submodule `modules/config` is deprecated in favor of the individual `modules/*`
+
 module "opsgenie_config" {
   source = "../../modules/config"
 

--- a/modules/config/README.md
+++ b/modules/config/README.md
@@ -1,5 +1,7 @@
 ## Config
 
+***NOTE: Usage of the submodule `modules/config` is deprecated in favor of the individual `modules/*`***
+
 Terraform module that configures a multitude of [Opsgenie resources](https://registry.terraform.io/providers/opsgenie/opsgenie/latest/docs). 
 Many resources have cross-resource dependencies, which may be simpler to handle within a single module in certain cases, such as using YAML configurations.
 


### PR DESCRIPTION
## what
* Add config deprecation docs

## why
* Deprecation in favor of v2 modules

## references
* Relates to https://github.com/cloudposse/terraform-opsgenie-incident-management/issues/33 (but does not close)
