### PR TITLE
Fix participant lookup in config/opsgenie_schedule_rotation resource

### DIFF
--- a/modules/config/schedule_rotations.tf
+++ b/modules/config/schedule_rotations.tf
@@ -16,7 +16,7 @@ resource "opsgenie_schedule_rotation" "this" {
 
     content {
       type = participant.value.type
-      id   = data.opsgenie_user.this[participant.value.username].id
+      id   = try(opsgenie_user.this[participant.value.username].id, data.opsgenie_user.this[participant.value.username].id)
     }
   }
 


### PR DESCRIPTION
## what

The current code only looks up user id for existing_users.
This change adds terraform managed users in the lookup.