### PR TITLE
[escalation] Single recipient per rule

### DIFF
--- a/examples/complete/escalation.tf
+++ b/examples/complete/escalation.tf
@@ -5,12 +5,12 @@ module "escalation" {
     name          = "${module.this.id}-escalation"
     owner_team_id = module.team.team_id
 
-    rule = {
-      recipients = [{
+    rules = [{
+      recipient = {
         type = "team"
         id   = module.sub_team.team_id
-      }]
-    }
+      }
+    }]
   }
 
   context = module.this.context

--- a/examples/config/resources/escalations.yaml
+++ b/examples/config/resources/escalations.yaml
@@ -7,6 +7,6 @@ escalations:
     condition: if-not-acked
     notify_type: default
     delay: 0
-    recipients:
-    - type: team
+    recipient:
+      type: team
       team_name: acme.dev.some-service

--- a/examples/config/resources/escalations.yaml
+++ b/examples/config/resources/escalations.yaml
@@ -2,9 +2,8 @@ escalations:
 - name: acme.dev.some-service-escalation
   description: "repo: https://github.com/acme/some-service;owner:David Lightman @David Lightman"
   owner_team_name: acme.dev
-  # please note - config uses `rules` but escalation modules uses `rule`
   rules:
-    condition: if-not-acked
+  - condition: if-not-acked
     notify_type: default
     delay: 0
     recipient:

--- a/examples/escalation/main.tf
+++ b/examples/escalation/main.tf
@@ -32,10 +32,10 @@ module "escalation" {
     owner_team_id = module.owner_team.team_id
 
     rule = {
-      recipients = [{
+      recipient = {
         type = "team"
         id   = module.escalation_team.team_id
-      }]
+      }
     }
   }
 

--- a/examples/escalation/main.tf
+++ b/examples/escalation/main.tf
@@ -32,6 +32,7 @@ module "escalation" {
     owner_team_id = module.owner_team.team_id
 
     rules = [{
+      delay = 0
       recipient = {
         type = "team"
         id   = module.escalation_team.team_id

--- a/examples/escalation/main.tf
+++ b/examples/escalation/main.tf
@@ -31,12 +31,12 @@ module "escalation" {
     name          = module.this.id
     owner_team_id = module.owner_team.team_id
 
-    rule = {
+    rules = [{
       recipient = {
         type = "team"
         id   = module.escalation_team.team_id
       }
-    }
+    }]
   }
 
   context = module.this.context

--- a/examples/team_routing_rule/main.tf
+++ b/examples/team_routing_rule/main.tf
@@ -17,7 +17,7 @@ module "escalation" {
   source = "../../modules/escalation"
 
   escalation = {
-    name          = "escalation"
+    name          = module.this.id
     owner_team_id = module.owner_team.team_id
 
     rules = [{

--- a/examples/team_routing_rule/main.tf
+++ b/examples/team_routing_rule/main.tf
@@ -20,14 +20,12 @@ module "escalation" {
     name          = "escalation"
     owner_team_id = module.owner_team.team_id
 
-    rule = {
-      recipients = [
-        {
-          type = "team"
-          id   = module.escalation_team.team_id
-        }
-      ]
-    }
+    rules = [{
+      recipient = {
+        type = "team"
+        id   = module.escalation_team.team_id
+      }
+    }]
   }
 
   context = module.this.context

--- a/modules/config/README.md
+++ b/modules/config/README.md
@@ -1,10 +1,10 @@
 ## Config
 
-Terraform module that configures a multitude of [Opsgenie resources](https://registry.terraform.io/providers/opsgenie/opsgenie/latest/docs). 
+Terraform module that configures a multitude of [Opsgenie resources](https://registry.terraform.io/providers/opsgenie/opsgenie/latest/docs).
 Many resources have cross-resource dependencies, which may be simpler to handle within a single module in certain cases, such as using YAML configurations.
 
-This module is designed to accept an input configuration map. 
-One nice way of handling this is by passing resource definitions from a YAML configuration file. 
+This module is designed to accept an input configuration map.
+One nice way of handling this is by passing resource definitions from a YAML configuration file.
 
 See below for details & examples.
 
@@ -46,12 +46,12 @@ escalations:
 - name: acme.dev.some-service-escalation
   description: "repo: https://github.com/acme/some-service;owner:David Lightman @David Lightman"
   owner_team_name: acme.dev
-  rule:
-    condition: if-not-acked
+  rules:
+  - condition: if-not-acked
     notify_type: default
     delay: 0
     recipient:
-    - type: team
+      type: team
       team_name: acme.dev.some-service
 ```
 

--- a/modules/config/README.md
+++ b/modules/config/README.md
@@ -50,7 +50,7 @@ escalations:
     condition: if-not-acked
     notify_type: default
     delay: 0
-    recipients:
+    recipient:
     - type: team
       team_name: acme.dev.some-service
 ```

--- a/modules/config/escalations.tf
+++ b/modules/config/escalations.tf
@@ -15,22 +15,18 @@ resource "opsgenie_escalation" "this" {
       notify_type = try(rules.value.notify_type, "default")
       delay       = try(rules.value.delay, 0)
 
-      dynamic "recipient" {
-        for_each = try(rules.value.recipients, [])
+      recipient {
+        type = rules.value.recipient["type"]
 
-        content {
-          type = recipient.value.type
-
-          id = lookup(recipient.value, "id", null) != null ? recipient.value.id : (
-            recipient.value.type == "team" ? opsgenie_team.this[recipient.value.team_name].id : (
-              recipient.value.type == "user" ? try(opsgenie_user.this[recipient.value.user_name].id, data.opsgenie_user.this[recipient.value.user_name].id) : (
-                recipient.value.type == "schedule" ? opsgenie_schedule.this[recipient.value.schedule_name].id : (
-                  null
-                )
+        id = lookup(rules.value.recipient, "id", null) != null ? rules.value.recipient.id : (
+          rules.value.recipient.type == "team" ? try(opsgenie_team.this[rules.value.recipient.team_name].id, data.opsgenie_team.this[rules.value.recipient.team_name].id) : (
+            rules.value.recipient.type == "user" ? try(opsgenie_user.this[rules.value.recipient.user_name].id, data.opsgenie_user.this[rules.value.recipient.user_name].id) : (
+              rules.value.recipient.type == "schedule" ? try(opsgenie_schedule.this[rules.value.recipient.schedule_name].id, data.opsgenie_schedule.this[rules.value.recipient.schedule_name].id) : (
+                null
               )
             )
           )
-        }
+        )
       }
     }
   }

--- a/modules/config/escalations.tf
+++ b/modules/config/escalations.tf
@@ -8,7 +8,7 @@ resource "opsgenie_escalation" "this" {
   owner_team_id = try(opsgenie_team.this[each.value.owner_team_name].id, null)
 
   dynamic "rules" {
-    for_each = try([each.value.rules], [])
+    for_each = try(each.value.rules, [])
 
     content {
       condition   = try(rules.value.condition, "if-not-acked")
@@ -16,9 +16,9 @@ resource "opsgenie_escalation" "this" {
       delay       = try(rules.value.delay, 0)
 
       recipient {
-        type = rules.value.recipient["type"]
+        type = rules.value.recipient.type
 
-        id = lookup(rules.value.recipient, "id", null) != null ? rules.value.recipient.id : (
+        id = try(rules.value.recipient.id, null) != null ? rules.value.recipient.id : (
           rules.value.recipient.type == "team" ? try(opsgenie_team.this[rules.value.recipient.team_name].id, data.opsgenie_team.this[rules.value.recipient.team_name].id) : (
             rules.value.recipient.type == "user" ? try(opsgenie_user.this[rules.value.recipient.user_name].id, data.opsgenie_user.this[rules.value.recipient.user_name].id) : (
               rules.value.recipient.type == "schedule" ? try(opsgenie_schedule.this[rules.value.recipient.schedule_name].id, data.opsgenie_schedule.this[rules.value.recipient.schedule_name].id) : (

--- a/modules/config/escalations.tf
+++ b/modules/config/escalations.tf
@@ -8,7 +8,7 @@ resource "opsgenie_escalation" "this" {
   owner_team_id = try(opsgenie_team.this[each.value.owner_team_name].id, null)
 
   dynamic "rules" {
-    for_each = try(each.value.rules, [])
+    for_each = each.value.rules
 
     content {
       condition   = try(rules.value.condition, "if-not-acked")

--- a/modules/escalation/README.md
+++ b/modules/escalation/README.md
@@ -17,12 +17,12 @@ module "escalation" {
     name          = module.label.id
     owner_team_id = module.owner_team.team_id
 
-    rule = {
-      recipient = {
-        type = "team"
-        id   = module.escalation_team.team_id
-      }
-    }
+    rules = [{
+        recipient = {
+            type = "team"
+            id   = module.escalation_team.team_id
+        }
+    }]
   }
 
 }

--- a/modules/escalation/README.md
+++ b/modules/escalation/README.md
@@ -18,10 +18,10 @@ module "escalation" {
     owner_team_id = module.owner_team.team_id
 
     rule = {
-      recipients = [{
+      recipient = {
         type = "team"
         id   = module.escalation_team.team_id
-      }]
+      }
     }
   }
 
@@ -31,7 +31,7 @@ module "escalation" {
 
 ## Inputs
 
-**Note:** `escalation` is a map for two reasons: 
+**Note:** `escalation` is a map for two reasons:
 - to be able to put whole configuration in yaml file
 - variables defined with type set are not robust enough (can't set default values)
 

--- a/modules/escalation/main.tf
+++ b/modules/escalation/main.tf
@@ -6,7 +6,7 @@ resource "opsgenie_escalation" "this" {
   owner_team_id = try(var.escalation.owner_team_id, null)
 
   dynamic "rules" {
-    for_each = try(var.escalation.rule, [])
+    for_each = try(var.escalation.rules, [])
 
     content {
       condition   = try(rules.value.condition, "if-not-acked")

--- a/modules/escalation/main.tf
+++ b/modules/escalation/main.tf
@@ -6,7 +6,7 @@ resource "opsgenie_escalation" "this" {
   owner_team_id = try(var.escalation.owner_team_id, null)
 
   dynamic "rules" {
-    for_each = try(var.escalation.rules, [])
+    for_each = var.escalation.rules
 
     content {
       condition   = try(rules.value.condition, "if-not-acked")

--- a/modules/escalation/main.tf
+++ b/modules/escalation/main.tf
@@ -5,17 +5,17 @@ resource "opsgenie_escalation" "this" {
   description   = try(var.escalation.description, var.escalation.name)
   owner_team_id = try(var.escalation.owner_team_id, null)
 
-  rules {
-    condition   = try(var.escalation.rule.condition, "if-not-acked")
-    notify_type = try(var.escalation.rule.notify_type, "default")
-    delay       = try(var.escalation.rule.delay, 0)
+  dynamic "rules" {
+    for_each = try(var.escalation.rule, [])
 
-    dynamic "recipient" {
-      for_each = try(var.escalation.rule.recipients, [])
+    content {
+      condition   = try(rules.value.condition, "if-not-acked")
+      notify_type = try(rules.value.notify_type, "default")
+      delay       = rules.value.delay
 
-      content {
-        id   = recipient.value.id
-        type = recipient.value.type
+      recipient {
+        type = rules.value.recipient.type
+        id   = try(rules.value.recipient.id, null)
       }
     }
   }
@@ -24,10 +24,10 @@ resource "opsgenie_escalation" "this" {
     for_each = try(var.escalation.repeat, null) != null ? ["true"] : []
 
     content {
-      wait_interval          = lookup(var.escalation.repeat, "wait_interval", 5)
-      count                  = lookup(var.escalation.repeat, "count", 0)
-      reset_recipient_states = lookup(var.escalation.repeat, "reset_recipient_states", true)
-      close_alert_after_all  = lookup(var.escalation.repeat, "close_alert_after_all", true)
+      wait_interval          = try(var.escalation.repeat.wait_interval, 5)
+      count                  = try(var.escalation.repeat.count, 0)
+      reset_recipient_states = try(var.escalation.repeat.reset_recipient_states, true)
+      close_alert_after_all  = try(var.escalation.repeat.close_alert_after_all, true)
     }
   }
 }

--- a/modules/escalation/main.tf
+++ b/modules/escalation/main.tf
@@ -11,7 +11,7 @@ resource "opsgenie_escalation" "this" {
     content {
       condition   = try(rules.value.condition, "if-not-acked")
       notify_type = try(rules.value.notify_type, "default")
-      delay       = rules.value.delay
+      delay       = try(rules.value.delay, 0)
 
       recipient {
         type = rules.value.recipient.type


### PR DESCRIPTION
## what

Rename `recipients` to `recipient` into Escalation rules.

And add the possibility to add multiple rules per escalation.

## why

Opsgenie only accepts a single recipient per escalation rule.

Worst than that, if we send more than one recipient, OpsGenie API will accept the payload will add only the first recipient and will return 200.

## references

[opsgenie_escalation terraform module](https://registry.terraform.io/providers/opsgenie/opsgenie/latest/docs/resources/escalation)