### PR TITLE
[schedule_rotation] Allow "none" as rotation participant

### DIFF
--- a/examples/config/resources/schedule_rotations.yaml
+++ b/examples/config/resources/schedule_rotations.yaml
@@ -9,6 +9,7 @@ schedule_rotations:
       username: opsgenie-test@cloudposse.com
     - type: user
       username: opsgenie-test-2@cloudposse.com
+    - type: none
     time_restriction:
       type: time-of-day
       restrictions:

--- a/modules/config/README.md
+++ b/modules/config/README.md
@@ -94,6 +94,7 @@ schedule_rotations:
     participants:
     - type: user
       username: opsgenie-test@cloudposse.com
+    - type: none
     - type: user
       username: opsgenie-test-2@cloudposse.com
     time_restriction:

--- a/modules/config/schedule_rotations.tf
+++ b/modules/config/schedule_rotations.tf
@@ -16,7 +16,7 @@ resource "opsgenie_schedule_rotation" "this" {
 
     content {
       type = participant.value.type
-      id   = try(opsgenie_user.this[participant.value.username].id, data.opsgenie_user.this[participant.value.username].id)
+      id   = participant.value.type == "none" ? null : try(opsgenie_user.this[participant.value.username].id, data.opsgenie_user.this[participant.value.username].id)
     }
   }
 


### PR DESCRIPTION
## what

Allow "none" as a participant on a rotation.

## why

This is a valid (and useful) value.

## references

[schedule_rotation opsgenie module](https://registry.terraform.io/providers/opsgenie/opsgenie/latest/docs/resources/schedule_rotation)