### PR TITLE
[config] Add squad intermediate abstraction

### DIFF
--- a/examples/config/main.tf
+++ b/examples/config/main.tf
@@ -3,12 +3,21 @@ provider "opsgenie" {
 }
 
 locals {
-  # Build a map of our various Opsgenie resources that will be used to iterate over each module
-  opsgenie_resources = merge([
-    for resource_file in fileset(path.cwd, "resources/*.yaml") : {
+  # load the config for each squad individually
+  # Temporary variable to hold the config for each squad
+  squads_configs = [
+    for resource_file in fileset(path.cwd, "squads/*/*.yaml") : {
       for k, v in yamldecode(file(resource_file)) : k => v
     }
-  ]...)
+  ]
+
+  # Build a map of our various Opsgenie resources that will be used to iterate over each module
+  # by "joining" the configs from many squads into a single map
+  opsgenie_resources = {
+    for key in distinct(flatten([for x in local.squads_configs : keys(x)])) :
+    key => flatten([
+    for m, n in local.squads_configs : n[key] if keys(n)[0] == key])
+  }
 }
 
 module "opsgenie_config" {


### PR DESCRIPTION
## what

Change a bit how the setup module works to enable multiple squads definitions, with each one having its own directory. To allow this we had to change a bit the "main" code to enable the merge of multiple different yaml "keys" together.

## why

This improves usability by enabling multiple squads in its own directory/file, avoiding huge yaml files.
