### PR TITLE
[config] Allow repeated resources names for multiple owners

### DIFF
--- a/modules/config/alert_policies.tf
+++ b/modules/config/alert_policies.tf
@@ -1,7 +1,7 @@
 # https://docs.opsgenie.com/docs/alert-api
 
 resource "opsgenie_alert_policy" "this" {
-  for_each = module.this.enabled ? { for policy in local.alert_policies : policy.name => policy } : {}
+  for_each = module.this.enabled ? { for policy in local.alert_policies : format("%s.%s", policy.owner_team_name, policy.name) => policy } : {}
 
   name               = each.value.name
   policy_description = try(each.value.policy_description, each.value.name)

--- a/modules/config/api_integrations.tf
+++ b/modules/config/api_integrations.tf
@@ -1,5 +1,5 @@
 resource "opsgenie_api_integration" "this" {
-  for_each = module.this.enabled ? { for integration in local.api_integrations : integration.name => integration } : {}
+  for_each = module.this.enabled ? { for integration in local.api_integrations : format("%s.%s", integration.owner_team_name, integration.name) => integration } : {}
 
   name = each.value.name
   type = each.value.type

--- a/modules/config/escalations.tf
+++ b/modules/config/escalations.tf
@@ -1,5 +1,5 @@
 resource "opsgenie_escalation" "this" {
-  for_each = module.this.enabled ? { for escalation in local.escalations : escalation.name => escalation } : tomap()
+  for_each = module.this.enabled ? { for escalation in local.escalations : format("%s.%s", escalation.owner_team_name, escalation.name) => escalation } : tomap()
 
   name        = each.value.name
   description = try(each.value.description, each.value.name)

--- a/modules/config/integration_actions.tf
+++ b/modules/config/integration_actions.tf
@@ -1,5 +1,5 @@
 resource "opsgenie_integration_action" "this" {
-  for_each = { for integration_action in local.integration_actions : integration_action.name => integration_action if module.this.enabled }
+  for_each = { for integration_action in local.integration_actions : format("%s.%s", integration_action.integration_name, integration_action.name) => integration_action if module.this.enabled }
 
   # Look up our integration id by name
   integration_id = try(opsgenie_api_integration.this[each.value.integration_name].id, null)

--- a/modules/config/notification_policies.tf
+++ b/modules/config/notification_policies.tf
@@ -1,8 +1,8 @@
 resource "opsgenie_notification_policy" "this" {
-  for_each = module.this.enabled ? { for policy in local.notification_policies : policy.name => policy } : tomap()
+  for_each = module.this.enabled ? { for policy in local.notification_policies : format("%s.%s", policy.team_name, policy.name) => policy } : tomap()
 
   enabled = try(each.value.enabled, true)
-  name    = each.key
+  name    = each.value.name
 
   # Look up our team id by name
   team_id            = opsgenie_team.this[each.value.team_name].id

--- a/modules/config/schedule_rotations.tf
+++ b/modules/config/schedule_rotations.tf
@@ -1,5 +1,5 @@
 resource "opsgenie_schedule_rotation" "this" {
-  for_each = module.this.enabled ? { for schedule_rotation in local.schedule_rotations : schedule_rotation.name => schedule_rotation } : tomap()
+  for_each = module.this.enabled ? { for schedule_rotation in local.schedule_rotations : format("%s.%s", schedule_rotation.schedule_name, schedule_rotation.name) => schedule_rotation } : tomap()
 
   name = each.value.name
   type = each.value.type

--- a/modules/config/schedules.tf
+++ b/modules/config/schedules.tf
@@ -1,5 +1,5 @@
 resource "opsgenie_schedule" "this" {
-  for_each = module.this.enabled ? { for schedule in local.schedules : schedule.name => schedule } : tomap()
+  for_each = module.this.enabled ? { for schedule in local.schedules : format("%s.%s", schedule.owner_team_name, schedule.name) => schedule } : tomap()
 
   enabled = try(each.value.enabled, true)
 

--- a/modules/config/service_incident_rules.tf
+++ b/modules/config/service_incident_rules.tf
@@ -1,5 +1,5 @@
 resource "opsgenie_service_incident_rule" "this" {
-  for_each = module.this.enabled ? { for service_incident_rule in local.service_incident_rules : service_incident_rule.name => service_incident_rule } : tomap()
+  for_each = module.this.enabled ? { for service_incident_rule in local.service_incident_rules : format("%s.%s", service_incident_rule.service_name, service_incident_rule.name) => service_incident_rule } : tomap()
 
   service_id = opsgenie_service.this[each.value.service_name].id
 

--- a/modules/config/services.tf
+++ b/modules/config/services.tf
@@ -1,5 +1,5 @@
 resource "opsgenie_service" "this" {
-  for_each = module.this.enabled ? { for service in local.services : service.name => service } : tomap()
+  for_each = module.this.enabled ? { for service in local.services : format("%s.%s", service.team_name, service.name) => service } : tomap()
 
   name        = each.value.name
   team_id     = opsgenie_team.this[each.value.team_name].id

--- a/modules/config/team_routing_rules.tf
+++ b/modules/config/team_routing_rules.tf
@@ -1,5 +1,5 @@
 resource "opsgenie_team_routing_rule" "this" {
-  for_each = module.this.enabled ? { for rule in local.team_routing_rules : rule.name => rule } : tomap()
+  for_each = module.this.enabled ? { for rule in local.team_routing_rules : format("%s.%s", rule.owner_team_name, rule.name) => rule } : tomap()
 
   name = each.value.name
 


### PR DESCRIPTION
## what

Allow us to setup two rules (e.g. escalations) with the same name for multiple teams.

## why

Many settings may want to use similar names for "resources" (rotations, schedules, escalations, alert policies, etc) and there it doesn't make sense to restrict this kind of usage.